### PR TITLE
set custom user agent

### DIFF
--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -168,7 +168,10 @@ module RegistersClient
     end
 
     def register_http_request(path)
-      headers = {}
+      headers = {
+        Authorization: @options[:api_key],
+        user_agent: 'CL'
+      }.compact
 
       unless @options[:api_key] == nil
         headers[:Authorization] = @options[:api_key]

--- a/spec/register_client_spec.rb
+++ b/spec/register_client_spec.rb
@@ -478,7 +478,7 @@ RSpec.describe RegistersClient::RegisterClient do
     it 'should not set the Auth header in the download request when API is not present' do
       options = {}
 
-      expect(RestClient).to receive(:get).with('https://country.test.openregister.org/download', {}).once
+      expect(RestClient).to receive(:get).with('https://country.test.openregister.org/download', user_agent: 'CL').once
 
       client = RegistersClient::RegisterClient.new(URI.parse('https://country.test.openregister.org'), @data_store, @page_size, options)
       client.send(:register_http_request, "https://country.test.openregister.org/download")
@@ -490,7 +490,16 @@ RSpec.describe RegistersClient::RegisterClient do
           api_key: api_key
       }
 
-      expect(RestClient).to receive(:get).with('https://country.test.openregister.org/download', { Authorization: api_key }).once
+      expect(RestClient).to receive(:get).with('https://country.test.openregister.org/download', Authorization: api_key, user_agent: 'CL').once
+
+      client = RegistersClient::RegisterClient.new(URI.parse('https://country.test.openregister.org'), @data_store, @page_size, options)
+      client.send(:register_http_request, "https://country.test.openregister.org/download")
+    end
+
+      it 'should set the user agent header on the request' do
+      options = {}
+
+      expect(RestClient).to receive(:get).with('https://country.test.openregister.org/download', user_agent: 'CL').once
 
       client = RegistersClient::RegisterClient.new(URI.parse('https://country.test.openregister.org'), @data_store, @page_size, options)
       client.send(:register_http_request, "https://country.test.openregister.org/download")


### PR DESCRIPTION
### Context
It it easier to track usage of client library if we set a custom user agent, currently downstream we expect `CL` https://github.com/openregister/deployment/blob/01f50d63b38f00e529bb510e3b0ae7af65c388bf/aws/lambda/node/log-api-key-to-cloudwatch/log-api-key-to-cloudwatch.js#L32

### Changes proposed in this pull request
Set custom user agent on requests

### Guidance to review
Custom user agent should be set on requests.

